### PR TITLE
The version of nd4j on which dl4j 0.0.3.2.7 depends is 0.0.3.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <name>DeepLearning4j Examples</name>
     <description>Examples of training different data sets</description>
     <properties>
-        <nd4j.version>0.0.3.5.5</nd4j.version>
+        <nd4j.version>0.0.3.5.4</nd4j.version>
         <dl4j.version>0.0.3.2.7</dl4j.version>
     </properties>
 


### PR DESCRIPTION
see : https://github.com/SkymindIO/deeplearning4j/blob/deeplearning4j-parent-0.0.3.2.7/pom.xml#L39